### PR TITLE
fix upConv usage

### DIFF
--- a/reconSpyr.m
+++ b/reconSpyr.m
@@ -91,6 +91,6 @@ res = upConv(res1, lo0filt, edges);
 
 %% residual highpass subband
 if any(levs == 0)
-   res = upConv( subMtx(pyr, pind(1,:)), hi0filt, edges, [1 1], [1 1], size(res), res);
+   upConv( subMtx(pyr, pind(1,:)), hi0filt, edges, [1 1], [1 1], size(res), res);
 end
  

--- a/reconSpyrLevs.m
+++ b/reconSpyrLevs.m
@@ -38,7 +38,7 @@ if any(levs == 1)
   for b = 1:nbands
     if any(bands == b)
       bfilt = reshape(bfilts(:,b), bfiltsz, bfiltsz);
-      res = upConv(reshape(pyr(ind:ind+prod(res_sz)-1), res_sz(1), res_sz(2)), ...
+      upConv(reshape(pyr(ind:ind+prod(res_sz)-1), res_sz(1), res_sz(2)), ...
 		  bfilt, edges, [1 1], [1 1], res_sz, res);
     end
     ind = ind + prod(res_sz);


### PR DESCRIPTION
This patch will solve the problem reported in #4.

As the help of `upConv` says:
```
>> help upConv
  RES = upConv(IM, FILT, EDGES, STEP, START, STOP, RES)

  ...
  RES is an optional result matrix.  The convolution result will be
  destructively added into this matrix.  If this argument is passed, the
  result matrix will not be returned. DO NOT USE THIS ARGUMENT IF
  YOU DO NOT UNDERSTAND WHAT THIS MEANS!!
  ...
```

So, what you can do here is to modify the code:

1. Not to pass the `RES` input argument
2. Not to receive the `RES` output argument

The problem with the following code is that `res` exists both on the left side and right side.

https://github.com/LabForComputationalVision/matlabPyrTools/blob/42e4602dd06a36282b16123e7f587c08f397b272/reconSpyr.m#L94

According to the `upConv` usage in reconSpyr.m, and reconSpyrLevs.m, the `res` variable is created in proper size and type, so you should omit the left side `res` output argument.