### PR TITLE
fix gcf usage

### DIFF
--- a/nextFig.m
+++ b/nextFig.m
@@ -16,4 +16,5 @@ if (exist('skip') ~= 1)
   skip = 1;
 end
   
-figure(1+mod(gcf-1+skip,maxfigs));
+figNumber = get(gcf, 'Number');
+figure(1+mod(figNumber-1+skip,maxfigs));


### PR DESCRIPTION
Starting in MATLAB R2014b, figure handles are object handles where previously they were integers. Now to get the associated number for the figure, query the new Number property.

See more information below.

https://jp.mathworks.com/matlabcentral/answers/157757-how-do-i-get-the-figure-number-in-matlab-r2014b